### PR TITLE
Fix #18: add support for splitting metadata to metadata script.

### DIFF
--- a/tests/satosa/scripts/test_satosa_saml_metadata.py
+++ b/tests/satosa/scripts/test_satosa_saml_metadata.py
@@ -1,3 +1,4 @@
+import glob
 import os
 
 from saml2.config import Config
@@ -18,9 +19,9 @@ class TestConstructSAMLMetadata:
         conf = Config()
         conf.cert_file = cert_and_key[0]
         security_ctx = security_context(conf)
-        metadata_files = [os.path.join(str(tmpdir), "frontend.xml"), os.path.join(str(tmpdir), "backend.xml")]
+        metadata_files = ["frontend.xml", "backend.xml"]
         for file in metadata_files:
-            md = MetaDataFile(None, file, security=security_ctx)
+            md = MetaDataFile(None, os.path.join(str(tmpdir), file), security=security_ctx)
             assert md.load()
 
     def test_saml_oidc(self, tmpdir, cert_and_key, satosa_config_dict, saml_frontend_config,
@@ -33,9 +34,46 @@ class TestConstructSAMLMetadata:
         conf = Config()
         conf.cert_file = cert_and_key[0]
         security_ctx = security_context(conf)
-        metadata_files = [os.path.join(str(tmpdir), "frontend.xml")]
-        for file in metadata_files:
+        md = MetaDataFile(None, os.path.join(str(tmpdir), "frontend.xml"), security=security_ctx)
+        assert md.load()
+
+        assert not os.path.isfile(os.path.join(str(tmpdir), "backend.xml"))
+
+    def test_split_frontend_metadata_to_separate_files(self, tmpdir, cert_and_key, satosa_config_dict,
+                                                       saml_mirror_frontend_config, saml_backend_config,
+                                                       oidc_backend_config):
+
+        satosa_config_dict["FRONTEND_MODULES"] = [saml_mirror_frontend_config]
+        satosa_config_dict["BACKEND_MODULES"] = [oidc_backend_config, saml_backend_config]
+
+        create_and_write_saml_metadata(satosa_config_dict, cert_and_key[1], cert_and_key[0], str(tmpdir), None,
+                                       split_frontend_metadata=True)
+
+        conf = Config()
+        conf.cert_file = cert_and_key[0]
+        security_ctx = security_context(conf)
+
+        file_pattern = "{}*.xml".format(saml_mirror_frontend_config["name"])
+        written_metadata_files = glob.glob(os.path.join(str(tmpdir), file_pattern))
+        assert len(written_metadata_files) == 2
+        for file in written_metadata_files:
             md = MetaDataFile(None, file, security=security_ctx)
             assert md.load()
 
-        assert not os.path.isfile(os.path.join(str(tmpdir), "backend.xml"))
+    def test_split_backend_metadata_to_separate_files(self, tmpdir, cert_and_key, satosa_config_dict,
+                                                      saml_frontend_config, saml_backend_config):
+
+        satosa_config_dict["FRONTEND_MODULES"] = [saml_frontend_config]
+        satosa_config_dict["BACKEND_MODULES"] = [saml_backend_config, saml_backend_config]
+
+        create_and_write_saml_metadata(satosa_config_dict, cert_and_key[1], cert_and_key[0], str(tmpdir), None,
+                                       split_backend_metadata=True)
+
+        conf = Config()
+        conf.cert_file = cert_and_key[0]
+        security_ctx = security_context(conf)
+
+        written_metadata_files = [saml_backend_config["name"], saml_backend_config["name"]]
+        for file in written_metadata_files:
+            md = MetaDataFile(None, os.path.join(str(tmpdir), "{}_0.xml".format(file)), security=security_ctx)
+            assert md.load()


### PR DESCRIPTION
Add flags 'split-frontend' and 'split-backend' to make it possible to
produce multiple files with only one entity descriptor per file instead
of merging all entity descriptor in an entities descriptor in one large
file.