### PR TITLE
Fix #19: don't assume 'lang' is specified in logo.

### DIFF
--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -297,7 +297,7 @@ class SAMLBackend(BackendModule):
                 for name in ui_info.get("display_name", []):
                     ui_info_desc.add_display_name(name["text"], name["lang"])
                 for logo in ui_info.get("logo", []):
-                    ui_info_desc.add_logo(logo["text"], logo["width"], logo["height"], logo["lang"])
+                    ui_info_desc.add_logo(logo["text"], logo["width"], logo["height"], logo.get("lang"))
                 description.ui_info = ui_info_desc
 
             entity_descriptions.append(description)

--- a/src/satosa/metadata_creation/description.py
+++ b/src/satosa/metadata_creation/description.py
@@ -77,20 +77,24 @@ class UIInfoDesc(object):
         """
         self._display_name.append({"text": text, "lang": lang})
 
-    def add_logo(self, text, width, height, lang):
+    def add_logo(self, text, width, height, lang=None):
         """
         Binds a logo to the given language
         :type text: str
         :type width: str
         :type height: str
-        :type lang: str
+        :type lang: Optional[str]
 
         :param text: Path to logo
         :param width: width of logo
         :param height: height of logo
         :param lang: language
         """
-        self._logos.append({"text": text, "width": width, "height": height, "lang": lang})
+
+        logo_entry ={"text": text, "width": width, "height": height}
+        if lang:
+            logo_entry["lang"] = lang
+        self._logos.append(logo_entry)
 
     def to_dict(self):
         """

--- a/tests/satosa/metadata_creation/test_description.py
+++ b/tests/satosa/metadata_creation/test_description.py
@@ -33,6 +33,14 @@ class TestUIInfoDesc(object):
         assert ui_info["display_name"] == [{"text": "my company", "lang": "en"}]
         assert ui_info["logo"] == [{"text": "logo.jpg", "width": 80, "height": 80, "lang": "en"}]
 
+    def test_to_dict_for_logo_without_lang(self):
+        desc = UIInfoDesc()
+        desc.add_logo("logo.jpg", 80, 80, None)
+
+        serialized = desc.to_dict()
+        ui_info = serialized["service"]["idp"]["ui_info"]
+        assert ui_info["logo"] == [{"text": "logo.jpg", "width": 80, "height": 80}]
+
     def test_to_dict_with_empty(self):
         desc = UIInfoDesc()
         assert desc.to_dict() == {}
@@ -69,13 +77,10 @@ class TestMetadataDescription(object):
         contact_desc.sur_name = "Tester"
         contact_desc.add_email_address("first_tester@example.com")
 
-        logo_data = "test data".encode("utf-8")
-
         ui_desc = UIInfoDesc()
         ui_desc.add_description("test", "en")
         ui_desc.add_display_name("my company", "en")
-        with patch("builtins.open", mock_open(read_data=logo_data)):
-            ui_desc.add_logo("logo.jpg", 80, 80, "en")
+        ui_desc.add_logo("http://example.com/logo.jpg", 80, 80, "en")
 
         desc = MetadataDescription("my_entity")
         desc.organization = org_desc


### PR DESCRIPTION
Since it's optional, be careful when fetching it and don't include
it in the produced metadata description if it's empty.