### PR TITLE
Make account linking a response micro service.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -45,7 +45,6 @@ in the [example directory](../example).
 | `MICRO_SERVICES` | string[] | `[statistics_service.yaml]` | list of plugin configuration file paths, describing enabled microservices |
 | `USER_ID_HASH_SALT` | string | `61a89d2db0b9e1e2` | salt used when creating the persistent user identifier, will be overriden by the environment variable `SATOSA_USER_ID_HASH_SALT` if it is set |
 | `CONSENT` | dict | see configuration of [Additional Services](#additional-services) | optional configuration of consent service |
-| `ACCOUNT_LINKING` | dict | see configuration of [Additional Services](#additional-services) | optional configuration of account linking service |
 | `LOGGING` | dict | see [Python logging.conf](https://docs.python.org/3/library/logging.config.html) | optional configuration of application logging |
 
 
@@ -57,8 +56,8 @@ in the [example directory](../example).
 | `redirect_url` | string | `https://localhost/redirect` | url to the endpoint where the user should be redirected for necessary interaction |
 | `sign_key`| string | `pki/consent.key` | path to key used for signing the requests to the service |
 
-If using the [CMService](https://github.com/its-dirg/CMservice) for consent management and the [ALService](https://github.com/its-dirg/ALservice) for account linking, the `redirect` parameter should be `https://<host>/consent` and `https://<host>/approve` in the respective configuration entry.
-
+If using the [CMService](https://github.com/its-dirg/CMservice) for consent management,
+the `redirect_url` parameter should be `https://<host>/consent`.
 
 ## <a name="attr_map" style="color:#000000">Attribute mapping configuration:</a> `internal_attributes.yaml`
 
@@ -476,6 +475,16 @@ rules:
         allow: ["*"]
         deny: ["requester1"]
 ```
+
+#### Account linking
+
+To allow account linking (multiple accounts at possibly different target providers are linked together as belonging to
+the same user), an external service can be used. See the [example config](../example/plugins/microservices/account_linking.yaml.example)
+which is intended to work with the [ALService](https://github.com/its-dirg/ALservice) (or any other service providing
+the same REST API).
+
+This micro service must be the first in the list of configured micro services in the `proxy_conf.yaml` to ensure
+correct functionality.
 
 ### Custom plugins
 

--- a/example/plugins/microservices/account_linking.yaml.example
+++ b/example/plugins/microservices/account_linking.yaml.example
@@ -1,0 +1,7 @@
+module: satosa.micro_services.account_linking.AccountLinking
+name: AccountLinking
+config:
+  enable: Yes
+  api_url: "https://localhost:8167"
+  redirect_url: "https://localhost:8167/approve"
+  sign_key: "pki/account_linking.key"

--- a/example/proxy_conf.yaml.example
+++ b/example/proxy_conf.yaml.example
@@ -19,11 +19,6 @@ CONSENT:
   api_url: "https://127.0.0.1:8166"
   redirect_url: "https://localhost:8166/consent"
   sign_key: "pki/mykey.pem"
-ACCOUNT_LINKING:
-  enable: Yes
-  api_url: "https://localhost:8167"
-  redirect_url: "https://localhost:8167/approve"
-  sign_key: "pki/account_linking.key"
 LOGGING:
   version: 1
   formatters:

--- a/src/satosa/micro_services/base.py
+++ b/src/satosa/micro_services/base.py
@@ -11,8 +11,9 @@ class MicroService(object):
     Abstract class for micro services
     """
 
-    def __init__(self, name, **kwargs):
+    def __init__(self, name, base_url, **kwargs):
         self.name = name
+        self.base_url = base_url
         self.next = None
 
     def process(self, context, data):

--- a/src/satosa/plugin_loader.py
+++ b/src/satosa/plugin_loader.py
@@ -209,7 +209,7 @@ def _load_microservice(plugin_config, plugin_filter):
     return _load_plugin_module(plugin_config, plugin_filter)
 
 
-def _load_microservices(plugin_paths, plugins, plugin_filter, internal_attributes):
+def _load_microservices(plugin_paths, plugins, plugin_filter, internal_attributes, base_url):
     loaded_plugin_modules = []
     with prepend_to_import_path(plugin_paths):
         for plugin_config in plugins:
@@ -220,7 +220,7 @@ def _load_microservices(plugin_paths, plugins, plugin_filter, internal_attribute
 
             if module_class:
                 instance = module_class(internal_attributes=internal_attributes, config=plugin_config.get("config"),
-                                        name=plugin_config["name"])
+                                        name=plugin_config["name"], base_url=base_url)
                 loaded_plugin_modules.append(instance)
 
     return loaded_plugin_modules
@@ -237,37 +237,43 @@ def _replace_variables_in_plugin_module_config(module_config, base_url, name):
     return json.loads(config)
 
 
-def load_request_microservices(plugin_path, plugins, internal_attributes):
+def load_request_microservices(plugin_path, plugins, internal_attributes, base_url):
     """
     Loads request micro services (handling incoming requests).
 
     :type plugin_path: list[str]
     :type plugins: list[str]
     :type internal_attributes: dict[string, dict[str, str | list[str]]]
+    :type base_url: str
     :rtype satosa.micro_service.service_base.RequestMicroService
 
     :param plugin_path: Path to the plugin directory
     :param plugins: A list with the name of the plugin files
+    :param: base_url: base url of the SATOSA server
     :return: Request micro service
     """
-    request_services = _load_microservices(plugin_path, plugins, _request_micro_service_filter, internal_attributes)
+    request_services = _load_microservices(plugin_path, plugins, _request_micro_service_filter, internal_attributes,
+                                           base_url)
     logger.info("Loaded request micro services: %s" % [type(k).__name__ for k in request_services])
     return request_services
 
 
-def load_response_microservices(plugin_path, plugins, internal_attributes):
+def load_response_microservices(plugin_path, plugins, internal_attributes, base_url):
     """
     Loads response micro services (handling outgoing responses).
 
     :type plugin_path: list[str]
     :type plugins: list[str]
     :type internal_attributes: dict[string, dict[str, str | list[str]]]
+    :type base_url: str
     :rtype satosa.micro_service.service_base.ResponseMicroService
 
     :param plugin_path: Path to the plugin directory
     :param plugins: A list with the name of the plugin files
+    :param: base_url: base url of the SATOSA server
     :return: Response micro service
     """
-    response_services = _load_microservices(plugin_path, plugins, _response_micro_service_filter, internal_attributes)
+    response_services = _load_microservices(plugin_path, plugins, _response_micro_service_filter, internal_attributes,
+                                            base_url)
     logger.info("Loaded response micro services: %s" % [type(k).__name__ for k in response_services])
     return response_services

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,6 +333,20 @@ def oidc_backend_config():
 
     return data
 
+@pytest.fixture
+def account_linking_module_config(signing_key_path):
+    account_linking_config = {
+        "module": "satosa.micro_services.account_linking.AccountLinking",
+        "name": "AccountLinking",
+        "config": {
+            "api_url": "http://account.example.com/api",
+            "redirect_url": "http://account.example.com/redirect",
+            "sign_key": signing_key_path,
+        }
+    }
+    return account_linking_config
+
+
 
 import atexit
 import random

--- a/tests/flows/test_account_linking.py
+++ b/tests/flows/test_account_linking.py
@@ -7,15 +7,12 @@ from satosa.satosa_config import SATOSAConfig
 
 
 class TestAccountLinking:
-    def test_full_flow(self, satosa_config_dict, signing_key_path):
+    def test_full_flow(self, satosa_config_dict, account_linking_module_config):
         api_url = "https://alservice.example.com/api"
         redirect_url = "https://alservice.examle.com/redirect"
-        satosa_config_dict["ACCOUNT_LINKING"] = {
-            "enable": True,
-            "api_url": api_url,
-            "redirect_url": redirect_url,
-            "sign_key": signing_key_path
-        }
+        account_linking_module_config["config"]["api_url"] = api_url
+        account_linking_module_config["config"]["redirect_url"] = redirect_url
+        satosa_config_dict["MICRO_SERVICES"].insert(0, account_linking_module_config)
 
         # application
         test_client = Client(make_app(SATOSAConfig(satosa_config_dict)), BaseResponse)

--- a/tests/satosa/micro_services/test_attribute_modifications.py
+++ b/tests/satosa/micro_services/test_attribute_modifications.py
@@ -4,7 +4,8 @@ from satosa.micro_services.attribute_modifications import FilterAttributeValues
 
 class TestFilterAttributeValues:
     def create_filter_service(self, attribute_filters):
-        filter_service = FilterAttributeValues(config=dict(attribute_filters=attribute_filters), name="test_filter")
+        filter_service = FilterAttributeValues(config=dict(attribute_filters=attribute_filters), name="test_filter",
+                                               base_url="https://satosa.example.com")
         filter_service.next = lambda ctx, data: data
         return filter_service
 

--- a/tests/satosa/micro_services/test_custom_routing.py
+++ b/tests/satosa/micro_services/test_custom_routing.py
@@ -17,7 +17,8 @@ def target_context(context):
 
 class TestDecideIfRequesterIsAllowed:
     def create_decide_service(self, rules):
-        decide_service = DecideIfRequesterIsAllowed(config=dict(rules=rules), name="test_decide_service")
+        decide_service = DecideIfRequesterIsAllowed(config=dict(rules=rules), name="test_decide_service",
+                                                    base_url="https://satosa.example.com")
         decide_service.next = lambda ctx, data: data
         return decide_service
 

--- a/tests/satosa/test_account_linking.py
+++ b/tests/satosa/test_account_linking.py
@@ -1,6 +1,5 @@
 import json
 import re
-from unittest.mock import Mock
 
 import pytest
 import requests
@@ -8,11 +7,10 @@ import responses
 from jwkest.jwk import rsa_load, RSAKey
 from jwkest.jws import JWS
 
-from satosa.account_linking import AccountLinkingModule
 from satosa.exception import SATOSAAuthenticationError
 from satosa.internal_data import InternalResponse, AuthenticationInformation
+from satosa.micro_services.account_linking import AccountLinking
 from satosa.response import Redirect
-from satosa.satosa_config import SATOSAConfig
 
 
 class TestAccountLinking():
@@ -24,125 +22,123 @@ class TestAccountLinking():
         return internal_response
 
     @pytest.fixture
-    def satosa_config(self, satosa_config_dict, signing_key_path):
-        account_linking_config = {
-            "enable": True,
-            "api_url": "https://localhost:8167",
-            "redirect_url": "https://localhost:8167/approve",
+    def account_linking_config(self, signing_key_path):
+        return {
+            "api_url": "http://account.example.com/api",
+            "redirect_url": "http://account.example.com/redirect",
             "sign_key": signing_key_path,
         }
 
-        satosa_config_dict["ACCOUNT_LINKING"] = account_linking_config
-        return SATOSAConfig(satosa_config_dict)
-
     @pytest.fixture(autouse=True)
-    def create_account_linking(self, satosa_config):
-        self.mock_callback = Mock(side_effect=lambda context, internal_resp: (context, internal_resp))
-        self.account_linking = AccountLinkingModule(satosa_config, self.mock_callback)
+    def create_account_linking(self, account_linking_config):
+        self.account_linking = AccountLinking(account_linking_config, name="AccountLinking",
+                                              base_url="https://satosa.example.com")
+        self.account_linking.next = lambda ctx, data: data
 
-    def test_disable_account_linking(self, satosa_config):
-        satosa_config["ACCOUNT_LINKING"]["enable"] = False
-        account_linking = AccountLinkingModule(satosa_config, self.mock_callback)
-        assert account_linking.enabled == False
+    def test_disable_account_linking(self, account_linking_config):
+        account_linking_config["enable"] = False
+        account_linking = AccountLinking(account_linking_config, name="AccountLinking",
+                                         base_url="https://satosa.example.com")
+        assert account_linking.enabled is False
         assert not hasattr(account_linking, "proxy_base")
-        account_linking.manage_al(None, None)
-        assert self.mock_callback.called
+        assert account_linking.process(None, None)
 
     @responses.activate
-    def test_existing_account_linking_with_known_known_uuid(self, satosa_config, internal_response, context):
+    def test_existing_account_linking_with_known_known_uuid(self, account_linking_config, internal_response, context):
         uuid = "uuid"
         data = {
             "idp": internal_response.auth_info.issuer,
             "id": internal_response.user_id,
-            "redirect_endpoint": satosa_config["BASE"] + "/account_linking/handle_account_linking"
+            "redirect_endpoint": self.account_linking.base_url + "/account_linking/handle_account_linking"
         }
-        key = RSAKey(key=rsa_load(satosa_config["ACCOUNT_LINKING"]["sign_key"]), use="sig", alg="RS256")
+        key = RSAKey(key=rsa_load(account_linking_config["sign_key"]), use="sig", alg="RS256")
         jws = JWS(json.dumps(data), alg=key.alg).sign_compact([key])
         responses.add(
             responses.GET,
-            "%s/get_id?jwt=%s" % (satosa_config["ACCOUNT_LINKING"]["api_url"], jws),
+            "%s/get_id?jwt=%s" % (account_linking_config["api_url"], jws),
             status=200,
             body=uuid,
             content_type="text/html",
             match_querystring=True
         )
 
-        self.account_linking.manage_al(context, internal_response)
+        self.account_linking.process(context, internal_response)
         assert internal_response.user_id == uuid
 
-    def test_full_flow(self, satosa_config, internal_response, context):
+    def test_full_flow(self, account_linking_config, internal_response, context):
         ticket = "ticket"
         with responses.RequestsMock() as rsps:
             rsps.add(
                 responses.GET,
-                "%s/get_id" % satosa_config["ACCOUNT_LINKING"]["api_url"],
+                "%s/get_id" % account_linking_config["api_url"],
                 status=404,
                 body=ticket,
                 content_type="text/html"
             )
-            result = self.account_linking.manage_al(context, internal_response)
+            result = self.account_linking.process(context, internal_response)
         assert isinstance(result, Redirect)
-        assert result.message.startswith(satosa_config["ACCOUNT_LINKING"]["redirect_url"])
+        assert result.message.startswith(account_linking_config["redirect_url"])
 
         data = {
             "idp": internal_response.auth_info.issuer,
             "id": internal_response.user_id,
-            "redirect_endpoint": satosa_config["BASE"] + "/account_linking/handle_account_linking"
+            "redirect_endpoint": self.account_linking.base_url + "/account_linking/handle_account_linking"
         }
-        key = RSAKey(key=rsa_load(satosa_config["ACCOUNT_LINKING"]["sign_key"]), use="sig", alg="RS256")
+        key = RSAKey(key=rsa_load(account_linking_config["sign_key"]), use="sig", alg="RS256")
         jws = JWS(json.dumps(data), alg=key.alg).sign_compact([key])
         uuid = "uuid"
         with responses.RequestsMock() as rsps:
             # account is linked, 200 OK
             rsps.add(
                 responses.GET,
-                "%s/get_id?jwt=%s" % (satosa_config["ACCOUNT_LINKING"]["api_url"], jws),
+                "%s/get_id?jwt=%s" % (account_linking_config["api_url"], jws),
                 status=200,
                 body=uuid,
                 content_type="text/html",
                 match_querystring=True
             )
-            context, internal_response = self.account_linking._handle_al_response(context)
+            internal_response = self.account_linking._handle_al_response(context)
         assert internal_response.user_id == uuid
 
     @responses.activate
-    def test_account_linking_failed(self, satosa_config, internal_response, context):
+    def test_account_linking_failed(self, account_linking_config, internal_response, context):
         ticket = "ticket"
         responses.add(
             responses.GET,
-            "%s/get_id" % satosa_config["ACCOUNT_LINKING"]["api_url"],
+            "%s/get_id" % account_linking_config["api_url"],
             status=404,
             body=ticket,
             content_type="text/html"
         )
 
-        result = self.account_linking.manage_al(context, internal_response)
+        result = self.account_linking.process(context, internal_response)
         assert isinstance(result, Redirect)
-        assert result.message.startswith(satosa_config["ACCOUNT_LINKING"]["redirect_url"])
+        assert result.message.startswith(account_linking_config["redirect_url"])
 
         # account linking endpoint still does not return an id
         with pytest.raises(SATOSAAuthenticationError):
             self.account_linking._handle_al_response(context)
 
     @responses.activate
-    def test_manage_al_handle_failed_connection(self, satosa_config, internal_response, context):
+    def test_manage_al_handle_failed_connection(self, account_linking_config, internal_response, context):
         exception = requests.ConnectionError("No connection")
-        responses.add(responses.GET, "%s/get_id" % satosa_config["ACCOUNT_LINKING"]["api_url"],
+        responses.add(responses.GET, "%s/get_id" % account_linking_config["api_url"],
                       body=exception)
 
         with pytest.raises(SATOSAAuthenticationError):
-            self.account_linking.manage_al(context, internal_response)
+            self.account_linking.process(context, internal_response)
 
     @pytest.mark.parametrize("http_status", [
         400, 401, 500
     ])
     @responses.activate
-    def test_manage_al_handle_bad_response_status(self, http_status, satosa_config, internal_response, context):
-        responses.add(responses.GET, "%s/get_id" % satosa_config["ACCOUNT_LINKING"]["api_url"],
+    def test_manage_al_handle_bad_response_status(self, http_status, account_linking_config, internal_response,
+                                                  context):
+        responses.add(responses.GET, "%s/get_id" % account_linking_config["api_url"],
                       status=http_status)
 
         with pytest.raises(SATOSAAuthenticationError):
-            self.account_linking.manage_al(context, internal_response)
+            self.account_linking.process(context, internal_response)
 
     def test_register_endpoints(self):
         url_map = self.account_linking.register_endpoints()

--- a/tests/satosa/test_routing.py
+++ b/tests/satosa/test_routing.py
@@ -21,8 +21,8 @@ class TestModuleRouter:
 
         request_micro_service_name = "RequestService"
         response_micro_service_name = "ResponseService"
-        microservices = [TestRequestMicroservice(request_micro_service_name),
-                         TestResponseMicroservice(response_micro_service_name)]
+        microservices = [TestRequestMicroservice(request_micro_service_name, base_url="https://satosa.example.com"),
+                         TestResponseMicroservice(response_micro_service_name, base_url="https://satosa.example.com")]
 
         self.router = ModuleRouter(frontends, backends, microservices)
 


### PR DESCRIPTION
Since micro services are allowed to register callback endpoints,
account linking no longer needs to be a custom module.