### PR TITLE
Use requester_name in the consent module.

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -102,7 +102,8 @@ class SATOSABase(object):
         state = context.state
         state[STATE_KEY] = {"requester": internal_request.requester}
         # TODO consent module should manage any state it needs by itself
-        context.state[consent.STATE_KEY] = {"filter": internal_request.approved_attributes or []}
+        context.state[consent.STATE_KEY] = {"filter": internal_request.approved_attributes or [],
+                                            "requester_name": internal_request.requester_name}
         satosa_logging(logger, logging.INFO,
                        "Requesting provider: {}".format(internal_request.requester), state)
 

--- a/src/satosa/micro_services/consent.py
+++ b/src/satosa/micro_services/consent.py
@@ -85,7 +85,7 @@ class Consent(ResponseMicroService):
             "attr": internal_response.attributes,
             "id": id_hash,
             "redirect_endpoint": "%s/consent%s" % (self.base_url, self.endpoint),
-            "requester_name": internal_response.requester
+            "requester_name": context.state[STATE_KEY]["requester_name"]
         }
         if self.locked_attr:
             consent_args["locked_attrs"] = [self.locked_attr]


### PR DESCRIPTION
This allows for better i18n in the consent UI, since
InternalRequest.requester_name contains all display names of the
requester separated by language.