### PR TITLE
Don't redirect directly to a single IdP if MDQ is used for metadata.

### DIFF
--- a/src/satosa/backends/saml2.py
+++ b/src/satosa/backends/saml2.py
@@ -70,7 +70,7 @@ class SAMLBackend(BackendModule):
 
         # if there is only one IdP in the metadata, bypass the discovery service
         idps = self.sp.metadata.identity_providers()
-        if len(idps) == 1:
+        if len(idps) == 1 and "mdq" not in self.config["sp_config"]["metadata"]:
             return self.authn_request(context, idps[0])
 
         try:

--- a/tests/satosa/backends/test_saml2.py
+++ b/tests/satosa/backends/test_saml2.py
@@ -154,6 +154,15 @@ class TestSAMLBackend:
         resp = samlbackend.start_auth(context, InternalRequest(None, None))
         self.assert_redirect_to_idp(resp, idp_conf)
 
+    def test_always_redirect_to_discovery_service_if_using_mdq(self, context, sp_conf, idp_conf):
+        # one IdP in the metadata, but MDQ also configured so should always redirect to the discovery service
+        sp_conf["metadata"]["inline"] = [create_metadata_from_config_dict(idp_conf)]
+        sp_conf["metadata"]["mdq"] = ["https://mdq.example.com"]
+        samlbackend = SAMLBackend(None, INTERNAL_ATTRIBUTES, {"sp_config": sp_conf, "disco_srv": DISCOSRV_URL,},
+                                  "base_url", "saml_backend")
+        resp = samlbackend.start_auth(context, InternalRequest(None, None))
+        self.assert_redirect_to_discovery_server(resp, sp_conf)
+
     def test_authn_request(self, context, idp_conf):
         resp = self.samlbackend.authn_request(context, idp_conf["entityid"])
         self.assert_redirect_to_idp(resp, idp_conf)


### PR DESCRIPTION
The MDQ instance caches the fetched metadata, so when one IdP has been
used, it will look like there is exactly one IdP in the metadata.
In this case SATOSA should *not* redirect directly to that IdP, instead
continue to redirect to the discovery server.

Requires #45.