### PR TITLE
Fix #49: Upgrade pyop dependency to get fix for custom OIDC 'sub'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     package_dir={'': 'src'},
     install_requires=[
         "oic>=0.8.4.0",
-        "pyop>=1.0.1",
+        "pyop==2.0.1",
         "pyjwkest==1.1.5",
         "pysaml2==4.2.0",
         "requests",


### PR DESCRIPTION
If the internal attributes mapping contains a mapping for the OIDC sub
claim, pyop will now allow that value to be passed instead of trying
to overwrite (and throw an exception).